### PR TITLE
Fix conntrack availability check on conntrack-tools 1.4.8+

### DIFF
--- a/src/bridge_wireguard.rs
+++ b/src/bridge_wireguard.rs
@@ -39,7 +39,7 @@ pub async fn verify(config: &ConfigInner) -> SilentResult<()> {
         ("ip link", "iproute2"),
         ("iptables --help", "iptables"),
         ("ip6tables --help", "iptables"),
-        ("conntrack help", "conntrack-tools"),
+        ("conntrack --help", "conntrack-tools"),
     ];
 
     for wg_type in Iterator::chain(


### PR DESCRIPTION
`conntrack help` (without `--`) exits nonzero on conntrack-tools 1.4.8:

```
$ conntrack help; echo $?
conntrack v1.4.8 (conntrack-tools): You need to supply the `--src' option
2
$ conntrack --help; echo $?
Command line interface for the connection tracking system. Version 1.4.8
0
```

This causes `verify()` to report conntrack as unavailable, disabling WireGuard bridge mode on systems where conntrack-tools is correctly installed.

One-line fix: `"conntrack help"` → `"conntrack --help"`, consistent with the `iptables --help` and `ip6tables --help` checks in the same function.